### PR TITLE
ENH: Add qt and pyvista options

### DIFF
--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -17,6 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-2019, windows-2022]
+        qt: [""]
+      include:
+        os: ubuntu-latest
+        qt: "qt"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -24,17 +28,19 @@ jobs:
 
       - name: Test Action
         uses: ./
+        with:
+          qt-libs: ${{ matrix.qt == 'qt' }}
 
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Install PyVista
         run: pip install pyvista
 
       - name: Test PyVista
-        run: python test_pyvista.py
+        run: python tests/test_pyvista.py
 
       - uses: actions/upload-artifact@v2
         with:
@@ -43,6 +49,14 @@ jobs:
 
       - name: Second test of PyVista
         run: python -c "import pyvista;pyvista.Cube().plot(screenshot='${{ matrix.os }}-cube.png')"
+
+      - name: Test Qt
+        if: matrix.qt == "qt"
+        run: |
+          set -eo pipefail
+          pip install PyQt6 matplotlib
+          python test_qt.py-c "import matplotlib; matplotlib.use('QtAgg'); import matplotlib.pyplot as plt; plt.figure(); backend = matplotlib.get_backend(); assert backend == 'QtAgg', backend"
+        shell: bash
 
       - uses: actions/upload-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ jobs:
         uses: pyvista/setup-headless-display-action@v1
 ```
 
+### Options
+
+- `qt` (default `false`): set to `true` to install libraries required for Qt
+  on Linux, e.g.:
+  ```yml
+      - uses: pyvista/setup-headless-display-action@v1
+        with:
+          qt: true
+  ```
+- `pyvista` (default `true`): set to `false` if you don't want to set env
+  vars to use PyVista in offscreen mode.
 
 ### 🖼️ PyVista Example
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,7 @@ runs:
 
     - name: Install Linux Qt dependencies
       if: runner.os == 'Linux' && inputs.qt != 'false'
+      shell: bash
       run: sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0
 
     - name: Install Windows GL Dependencies

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,30 @@
 name: 'setup-headless-display-action'
 description: 'Setup a headless display on Linux and Windows'
 author: PyVista Developers'
+inputs:
+  pyvista:
+    description: "Set PyVista env vars for headless mode"
+    required: false
+    default: true
+  qt:
+    description: "Install libraries required for Qt on Linux"
+    required: false
+    default: false
 branding:
   icon: 'monitor'
   color: 'blue'
 runs:
   using: "composite"
   steps:
-    - name: Install Linux GL Dependencies
+
+    - name: Install Linux dependencies
       if: runner.os == 'Linux'
       shell: bash
-      run: sudo apt-get update && sudo apt-get install libgl1-mesa-glx xvfb -y
+      run: sudo apt update && sudo apt install libgl1-mesa-glx xvfb -y
+
+    - name: Install Linux Qt dependencies
+      if: runner.os == 'Linux' && inputs.qt != 'false'
+      run: sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0
 
     - name: Install Windows GL Dependencies
       if: runner.os == 'Windows'
@@ -28,19 +42,15 @@ runs:
         export DISPLAY=:99.0
         echo "DISPLAY=:99.0" >> $GITHUB_ENV
         Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-
-    - name: Give xvfb some time to start on Linux
-      if: runner.os == 'Linux'
-      shell: bash
-      run: sleep 3
+        sleep 3
 
     - name: Configure for PyVista on Linux and macOS
-      if: runner.os != 'Windows'
+      if: runner.os != 'Windows' && inputs.pyvista != 'false'
       shell: bash
       run: echo "PYVISTA_OFF_SCREEN=true" >> $GITHUB_ENV
 
     - name: Configure for PyVista on Windows
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && inputs.pyvista != 'false'
       shell: powershell
       run: |
         chcp 65001 #set code page to utf-8

--- a/tests/test_pyvista.py
+++ b/tests/test_pyvista.py
@@ -1,4 +1,5 @@
 """Quickly check if VTK off screen plotting works."""
+from pathlib import Path
 import pyvista
 from pyvista.plotting import system_supports_plotting
 
@@ -6,4 +7,5 @@ print(f'system_supports_plotting: {system_supports_plotting()}')
 assert system_supports_plotting()
 # pyvista.OFF_SCREEN = True  # should be set by Action in Env
 sphere = pyvista.Sphere()
-pyvista.plot(sphere, screenshot='sphere.png')
+out_path = Path(__file__).parent / '..' / 'sphere.png'
+pyvista.plot(sphere, screenshot=out_path)

--- a/tests/test_qt.py
+++ b/tests/test_qt.py
@@ -1,0 +1,6 @@
+import matplotlib
+matplotlib.use('QtAgg')
+import matplotlib.pyplot as plt
+plt.figure()
+backend = matplotlib.get_backend()
+assert backend == 'QtAgg', backend


### PR DESCRIPTION
1. Add `pyvista: true` default option to make it clear that by default env vars are set for PyVista offscreen mode
2. Add `qt: false` default option to allow `true` to add libraries needed for Qt
3. Create `tests/` directory and move `test_pyvista.py` there
4. Add test that Qt works on all platforms (easily done via matplotlib)

@banesullivan to me Qt is in scope even for the PyVista org, as we can/should use this for PyVistaQt!