### PR TITLE
Update version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Setup a headless display on Linux and Windows (not needed on MacOS)
 
 ```yml
 - name: Setup headless display
-  uses: pyvista/setup-headless-display-action@v1
+  uses: pyvista/setup-headless-display-action@v2
 ```
 
 ## 🚀 Usage
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup headless display
-        uses: pyvista/setup-headless-display-action@v1
+        uses: pyvista/setup-headless-display-action@v2
 ```
 
 ### Options
@@ -37,7 +37,7 @@ jobs:
 - `qt` (default `false`): set to `true` to install libraries required for Qt
   on Linux, e.g.:
   ```yml
-      - uses: pyvista/setup-headless-display-action@v1
+      - uses: pyvista/setup-headless-display-action@v2
         with:
           qt: true
   ```
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup headless display
-        uses: pyvista/setup-headless-display-action@v1
+        uses: pyvista/setup-headless-display-action@v2
 
       - name: Setup Python
         uses: actions/setup-python@v1


### PR DESCRIPTION
The readme describes the `qt` input added in v2, but still uses v1.  So it's a no-op for anyone following the readme:

```
Warning: Unexpected input(s) 'qt', valid inputs are ['']
Run pyvista/setup-headless-display-action@v1
  with:
    qt: true
  env:
    pythonLocation: C:\hostedtoolcache\windows\Python\3.8.10\x64
    PKG_CONFIG_PATH: C:\hostedtoolcache\windows\Python\3.8.10\x64/lib/pkgconfig
    Python_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
    Python2_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
    Python3_ROOT_DIR: C:\hostedtoolcache\windows\Python\3.8.10\x64
```