### PR TITLE
feat: allow installing specific Mesa3D release

### DIFF
--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [macos-14, macos-13, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-2019, windows-2022]
         qt: [""]
+        mesa: [""]
         include:
           - os: ubuntu-20.04
             qt: "pyqt5"
@@ -25,6 +26,7 @@ jobs:
             qt: "pyqt6"
           - os: windows-latest
             qt: "pyqt6"
+            mesa: "latest"
           - os: ubuntu-latest
             qt: "pyside6"
     runs-on: ${{ matrix.os }}
@@ -34,6 +36,7 @@ jobs:
         uses: ./
         with:
           qt: ${{ matrix.qt != '' }}
+          mesa3d-release: ${{ matrix.mesa || '24.3.0' }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
 - `pyvista` (default `true`): set to `false` if you don't want to set env
   vars to use PyVista in offscreen mode.
 
-- `mesa3d-release` (default `latest`): set to a specific release to install
+- `mesa3d-release` (default `24.3.0`): set to a specific release to install
   that version of Mesa3D. This is only applicable for Windows. For example,
   to install Mesa3D 21.2.5:
   ```yml
@@ -51,6 +51,7 @@ jobs:
         with:
           mesa3d-release: 21.2.5
   ```
+  You can also use `latest` to use the latest release version.
 
 ### 🖼️ PyVista Example
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ jobs:
 - `pyvista` (default `true`): set to `false` if you don't want to set env
   vars to use PyVista in offscreen mode.
 
+- `mesa3d-release` (default `latest`): set to a specific release to install
+  that version of Mesa3D. This is only applicable for Windows. For example,
+  to install Mesa3D 21.2.5:
+  ```yml
+      - uses: pyvista/setup-headless-display-action@v3
+        with:
+          mesa3d-release: 21.2.5
+  ```
+
 ### 🖼️ PyVista Example
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,6 @@ runs:
           echo "Using specified Mesa3D release version..."
           export MESA3D_VERSION=${{ inputs.mesa3d-release }}
         fi
-        echo "Mesa3D version to be used: ${MESA3D_VERSION}"
         echo "MESA3D_VERSION=${MESA3D_VERSION}" | tee -a $GITHUB_ENV
 
     - name: Install OpenGL on Windows

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
         else
           export MESA3D_VERSION=${{ inputs.mesa3d-release }}
         fi
-        echo "MESA3D_VERSION=${MESA3D_VERSION}" >> $GITHUB_ENV
+        echo "MESA3D_VERSION=${MESA3D_VERSION}" | tee -a $GITHUB_ENV
 
     - name: Install OpenGL on Windows
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.mesa3d-release }}" == "latest" ]; then
-          export MESA3D_VERSION=$(curl -s https://api.github.com/repos/pal1000/mesa-dist-win/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+          export MESA3D_VERSION=$(curl -s https://api.github.com/repos/pal1000/mesa-dist-win/releases/latest | grep -o '"tag_name": ".*"' | sed 's/"tag_name": "\(.*\)"/\1/')
         else
           export MESA3D_VERSION=${{ inputs.mesa3d-release }}
         fi

--- a/action.yml
+++ b/action.yml
@@ -66,10 +66,13 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.mesa3d-release }}" == "latest" ]; then
+          echo "Fetching latest Mesa3D release version..."
           export MESA3D_VERSION=$(curl -s https://api.github.com/repos/pal1000/mesa-dist-win/releases/latest | grep -o '"tag_name": ".*"' | sed 's/"tag_name": "\(.*\)"/\1/')
         else
+          echo "Using specified Mesa3D release version..."
           export MESA3D_VERSION=${{ inputs.mesa3d-release }}
         fi
+        echo "Mesa3D version to be used: ${MESA3D_VERSION}"
         echo "MESA3D_VERSION=${MESA3D_VERSION}" | tee -a $GITHUB_ENV
 
     - name: Install OpenGL on Windows

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,12 @@ inputs:
     description: "Install libraries required for Qt on Linux"
     required: false
     default: false
+  mesa3d-release:
+    description: |
+      Mesa3D release to install (by default, the latest release is installed).
+      This is only used on Windows.
+    required: false
+    default: "latest"
 branding:
   icon: "monitor"
   color: "blue"
@@ -54,6 +60,17 @@ runs:
           libxkbcommon-x11-0 \
           mesa-utils \
           x11-utils
+
+    - name: Determine OpenGL version to install on Windows
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        if [ "${{ inputs.mesa3d-release }}" == "latest" ]; then
+          export MESA3D_VERSION=$(curl -s https://api.github.com/repos/pal1000/mesa-dist-win/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+        else
+          export MESA3D_VERSION=${{ inputs.mesa3d-release }}
+        fi
+        echo "MESA3D_VERSION=${MESA3D_VERSION}" >> $GITHUB_ENV
 
     - name: Install OpenGL on Windows
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
       Mesa3D release to install (by default, the latest release is installed).
       This is only used on Windows.
     required: false
-    default: "latest"
+    default: "24.3.0"
 branding:
   icon: "monitor"
   color: "blue"

--- a/windows/install_opengl.sh
+++ b/windows/install_opengl.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 set -exo pipefail
 ls -alt /C/Windows/System32/opengl32.dll
-VER="24.2.7"
-NAME="mesa3d-${VER}-release-msvc"
-curl -LO https://github.com/pal1000/mesa-dist-win/releases/download/${VER}/${NAME}.7z
+
+# Check if MESA3D_VERSION variable is set
+if [ -z "${MESA3D_VERSION}" ]; then
+  echo "MESA3D_VERSION is not set. Required to install Mesa3D..."
+  exit 1
+fi
+
+NAME="mesa3d-${MESA3D_VERSION}-release-msvc"
+curl -LO https://github.com/pal1000/mesa-dist-win/releases/download/${MESA3D_VERSION}/${NAME}.7z
 7z x ${NAME}.7z -o./${NAME}
 mv -v ${NAME}/x64/* /C/Windows/System32/
 rm -Rf ${NAME}

--- a/windows/install_opengl.sh
+++ b/windows/install_opengl.sh
@@ -11,8 +11,9 @@ fi
 NAME="mesa3d-${MESA3D_VERSION}-release-msvc"
 curl -LO https://github.com/pal1000/mesa-dist-win/releases/download/${MESA3D_VERSION}/${NAME}.7z
 7z x ${NAME}.7z -o./${NAME}
-mv -v ${NAME}/x64/* /C/Windows/System32/
-rm -Rf ${NAME}
+# Run systemwidedeploy.cmd file: option 1) Install OpenGL drivers & 7) Update system-wide deployment
+cmd.exe //c "${NAME}\systemwidedeploy.cmd 1"
+cmd.exe //c "${NAME}\systemwidedeploy.cmd 7"
 # takeown "/f" "C:\Windows\System32\opengl32.dll"
 # icacls "C:\Windows\System32\opengl32.dll" /grant "$USERNAME:F"
 ls -alt /C/Windows/System32/opengl32.dll

--- a/windows/install_opengl.sh
+++ b/windows/install_opengl.sh
@@ -14,6 +14,7 @@ curl -LO https://github.com/pal1000/mesa-dist-win/releases/download/${MESA3D_VER
 # Run systemwidedeploy.cmd file: option 1) Install OpenGL drivers & 7) Update system-wide deployment
 cmd.exe //c "${NAME}\systemwidedeploy.cmd 1"
 cmd.exe //c "${NAME}\systemwidedeploy.cmd 7"
+rm -Rf ${NAME}
 # takeown "/f" "C:\Windows\System32\opengl32.dll"
 # icacls "C:\Windows\System32\opengl32.dll" /grant "$USERNAME:F"
 ls -alt /C/Windows/System32/opengl32.dll


### PR DESCRIPTION
A user might want to install a specific version of Mesa3D on their self-hosted runner or GitHub runner. This change would allow them to do so. Also, it will allow the action, by default, to always pull the latest Mesa3D version available rather than a hard-coded one. See commit https://github.com/pyvista/setup-headless-display-action/pull/22/commits/b2a733a9a3dd8baca9f3b1ee6bd91bcd55749fd1

Furthermore - we should use the installers that are shipped by Mesa3D in order to avoid DLL incompatibility issues. See commits https://github.com/pyvista/setup-headless-display-action/pull/22/commits/d6dd86a3f0ccdab45713646ea93dd4b636f7c996 and https://github.com/pyvista/setup-headless-display-action/pull/22/commits/adb571e2ed9c67e63bea203e5a36060eaaaca50f

Added documentation on how to use the input, and modified the action and bash scripts as well. Let me know if there's anything else I can contribute with!