### PR TITLE
add retries and no-revoke to mesa3d curl

### DIFF
--- a/windows/install_opengl.sh
+++ b/windows/install_opengl.sh
@@ -9,7 +9,7 @@ if [ -z "${MESA3D_VERSION}" ]; then
 fi
 
 NAME="mesa3d-${MESA3D_VERSION}-release-msvc"
-curl -LO https://github.com/pal1000/mesa-dist-win/releases/download/${MESA3D_VERSION}/${NAME}.7z
+curl -LO --retry 3 --ssl-no-revoke https://github.com/pal1000/mesa-dist-win/releases/download/${MESA3D_VERSION}/${NAME}.7z
 7z x ${NAME}.7z -o./${NAME}
 # Run systemwidedeploy.cmd file: option 1) Install OpenGL drivers & 7) Update system-wide deployment
 cmd.exe //c "${NAME}\systemwidedeploy.cmd 1"


### PR DESCRIPTION
I've been seeing [this error](https://github.com/pyapp-kit/ndv/actions/runs/13216398891/job/36896172942?pr=109#step:4:48) somewhat frequently recently on the mesa3d download step:

```sh
Run pyvista/setup-headless-display-action@v3
Run if [ "24.3.0" == "latest" ]; then
Using specified Mesa3D release version...
MESA3D_VERSION=24.3.0
Run bash D:\a\_actions\pyvista\setup-headless-display-action\v3\windows\install_opengl.sh
  bash D:\a\_actions\pyvista\setup-headless-display-action\v3\windows\install_opengl.sh
  shell: C:\Windows\system32\cmd.EXE /D /E:ON /V:OFF /S /C "CALL "{0}""
  env:
    UV_PYTHON: 3.10
    UV_FROZEN: 1
    UV_TOOL_BIN_DIR: D:\a\_temp\uv-tool-bin-dir
    UV_TOOL_DIR: D:\a\_temp\uv-tool-dir
    UV_CACHE_DIR: D:\a\_temp\setup-uv-cache
    MESA3D_VERSION: 24.3.0
+ ls -alt /C/Windows/System32/opengl32.dll
-rwxr-xr-x 2 runneradmin 197121 937984 Jan 12 08:23 /C/Windows/System32/opengl32.dll
+ '[' -z 24.3.0 ']'
+ NAME=mesa3d-24.3.0-release-msvc
+ curl -LO https://github.com/pal1000/mesa-dist-win/releases/download/24.3.0/mesa3d-24.3.0-release-msvc.7z
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (35) schannel: next InitializeSecurityContext failed: CRYPT_E_REVOCATION_OFFLINE (0x80092013) - The revocation function was unable to check revocation because the revocation server was offline.
```

simply rerunning often works.  So this job adds a retry to the curl... and also uses `--ssl-no-revoke`.  Everything I've read suggests thats safe in this case because:

- github.com itself uses strong https encryption
- github enforces certificate validity (even if curl skips the check, github won't serve files under a revoked certificate)
- man-in-the-middle is unlikely on the connection to github.com
 