### PR TITLE
feat: install osmesa off-screen renderer on Windows runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ jobs:
 
   You can also use `latest` to use the latest release version.
 
+- `install-mesa3d-offscreen` (default `false`): set to `true` to install the
+  offscreen version of Mesa3D on Windows. This is only applicable for Windows.
+  This will also set the `VTK_DEFAULT_OPENGL_WINDOW` environment variable to
+  `vtkOSOpenGLRenderWindow` based on the [VTK Runtime settings](https://docs.vtk.org/en/latest/advanced/runtime_settings.html)
+  For example:
+
+  ```yml
+      - uses: pyvista/setup-headless-display-action@v3
+        with:
+          install-mesa3d-offscreen: true
+  ```
+
 ### 🖼️ PyVista Example
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
       This is only used on Windows.
     required: false
     default: "24.3.0"
-  install-mesa-offscreen:
+  install-mesa3d-offscreen:
     description: |
       Install Mesa3D off-screen renderer on Windows (by default, it is not installed).
       This is only used on Windows.
@@ -90,7 +90,7 @@ runs:
         echo "MESA3D_VERSION=${MESA3D_VERSION}" | tee -a $GITHUB_ENV
 
     - name: Determine if off-screen renderer is needed on Windows
-      if: runner.os == 'Windows' && inputs.install-mesa-offscreen == 'true'
+      if: runner.os == 'Windows' && inputs.install-mesa3d-offscreen == 'true'
       shell: bash
       run: |
         echo "Installing Mesa3D off-screen renderer..."
@@ -124,7 +124,7 @@ runs:
       run: echo "PYVISTA_OFF_SCREEN=true" >> $GITHUB_ENV
 
     - name: Configure Mesa3D for PyVista/VTK (on Windows)
-      if: runner.os == 'Windows' && inputs.install-mesa-offscreen == 'true'
+      if: runner.os == 'Windows' && inputs.install-mesa3d-offscreen == 'true'
       shell: bash
       run: |
         echo "VTK_DEFAULT_OPENGL_WINDOW=vtkOSOpenGLRenderWindow" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -127,4 +127,4 @@ runs:
       if: runner.os == 'Windows' && inputs.install-mesa-offscreen == 'true'
       shell: bash
       run: |
-        echo "VTK_DEFAULT_OPENGL_WINDOW='vtkOSOpenGLRenderWindow'" >> $GITHUB_ENV
+        echo "VTK_DEFAULT_OPENGL_WINDOW=vtkOSOpenGLRenderWindow" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ inputs:
       This is only used on Windows.
     required: false
     default: "24.3.0"
+  install-mesa-offscreen:
+    description: |
+      Install Mesa3D off-screen renderer on Windows (by default, it is not installed).
+      This is only used on Windows.
+    required: false
+    default: "false"
 branding:
   icon: "monitor"
   color: "blue"
@@ -83,6 +89,14 @@ runs:
         fi
         echo "MESA3D_VERSION=${MESA3D_VERSION}" | tee -a $GITHUB_ENV
 
+    - name: Determine if off-screen renderer is needed on Windows
+      if: runner.os == 'Windows' && inputs.install-mesa-offscreen == 'true'
+      shell: bash
+      run: |
+        echo "Installing Mesa3D off-screen renderer..."
+        export MESA3D_OFFSCREEN="true"
+        echo "MESA3D_OFFSCREEN=${MESA3D_OFFSCREEN}" | tee -a $GITHUB_ENV
+
     - name: Install OpenGL on Windows
       if: runner.os == 'Windows'
       shell: cmd
@@ -108,3 +122,9 @@ runs:
       if: inputs.pyvista != 'false'
       shell: bash
       run: echo "PYVISTA_OFF_SCREEN=true" >> $GITHUB_ENV
+
+    - name: Configure Mesa3D for PyVista/VTK (on Windows)
+      if: runner.os == 'Windows' && inputs.install-mesa-offscreen == 'true'
+      shell: bash
+      run: |
+        echo "VTK_DEFAULT_OPENGL_WINDOW='vtkOSOpenGLRenderWindow'" >> $GITHUB_ENV

--- a/windows/install_opengl.sh
+++ b/windows/install_opengl.sh
@@ -11,10 +11,20 @@ fi
 NAME="mesa3d-${MESA3D_VERSION}-release-msvc"
 curl -LO --retry 3 --ssl-no-revoke https://github.com/pal1000/mesa-dist-win/releases/download/${MESA3D_VERSION}/${NAME}.7z
 7z x ${NAME}.7z -o./${NAME}
-# Run systemwidedeploy.cmd file: option 1) Install OpenGL drivers & 7) Update system-wide deployment
+# Run systemwidedeploy.cmd file:
+#  option 1) Install OpenGL drivers 
+#  option 5) Mesa3D off-screen render driver gallium version (osmesa gallium)
+#  option 7) Update system-wide deployment
 cmd.exe //c "${NAME}\systemwidedeploy.cmd 1"
+if [ "${MESA3D_OFFSCREEN}" == "true" ]; then
+  echo "Installing off-screen render driver gallium version (osmesa gallium)"
+  cmd.exe //c "${NAME}\systemwidedeploy.cmd 5"
+fi
 cmd.exe //c "${NAME}\systemwidedeploy.cmd 7"
 rm -Rf ${NAME}
 # takeown "/f" "C:\Windows\System32\opengl32.dll"
 # icacls "C:\Windows\System32\opengl32.dll" /grant "$USERNAME:F"
 ls -alt /C/Windows/System32/opengl32.dll
+if [ "${MESA3D_OFFSCREEN}" == "true" ]; then
+  ls -alt /C/Windows/System32/osmesa.dll
+fi


### PR DESCRIPTION
Although we were using the installer on Windows, we were not providing the osmesa.dll to the systemwide installation. This new implementation fixes it by adding it to the ``install_opengl.sh`` script as an optional feature (in case users want to benefit from it). By default, it is not enabled to avoid breaking changes.

It also defines ``VTK_DEFAULT_OPENGL_WINDOW=vtkOSOpenGLRenderWindow`` which is needed to force the usage of osmesa.dll based on https://docs.vtk.org/en/latest/advanced/runtime_settings.html

README has been adapted and new action inputs are created.