### PR TITLE
ci: disabling ubuntu 20.04 images

### DIFF
--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -20,6 +20,8 @@ jobs:
         qt: [""]
         mesa: [""]
         include:
+          - os: ubuntu-22.04
+            qt: "pyqt5"
           - os: ubuntu-24.04
             qt: "pyqt6"
           - os: windows-latest

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -16,12 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-13, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-2019, windows-2022]
+        os: [macos-14, macos-13, ubuntu-24.04, ubuntu-22.04, windows-2019, windows-2022]
         qt: [""]
         mesa: [""]
         include:
-          - os: ubuntu-20.04
-            qt: "pyqt5"
           - os: ubuntu-24.04
             qt: "pyqt6"
           - os: windows-latest


### PR DESCRIPTION
As title says. Coming from https://github.com/pyvista/setup-headless-display-action/pull/29#issuecomment-2821648843