### PR TITLE
Add missing apt package for qt6 deps

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,8 @@ runs:
           libxcb-xinput0 \
           libxkbcommon-x11-0 \
           mesa-utils \
-          x11-utils
+          x11-utils \
+          libpulse0
 
     - name: Determine OpenGL version to install on Windows
       if: runner.os == 'Windows'


### PR DESCRIPTION
Resolve #46 by adding `libpulse0` to the list of system dependencies for installation.